### PR TITLE
feat(ipv6): bind galera wsrep on all interfaces and make it IPv6-ready

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,7 +37,7 @@ func (c *ConfigFile) Marshal(podName, mariadbRootPassword string) ([]byte, error
 		return nil, errors.New("MariaDB Galera not enabled, unable to render config file")
 	}
 	tpl := createTpl("galera", `[mariadb]
-bind-address=0.0.0.0
+bind-address=*
 default_storage_engine=InnoDB
 binlog_format=row
 innodb_autoinc_lock_mode=2

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,6 +48,7 @@ wsrep_provider=/usr/lib/galera/libgalera_smm.so
 wsrep_cluster_address="{{ .ClusterAddress }}"
 wsrep_cluster_name=mariadb-operator
 wsrep_slave_threads={{ .Threads }}
+wsrep_provider_options="gmcast.listen_addr=tcp://[::]:4567; ist.recv_addr={{ .Pod }}.{{ .Service }}:4568"
 
 # Node configuration
 wsrep_node_address="{{ .Pod }}.{{ .Service }}"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,9 +66,12 @@ sockopt=",pf=ip6"
 `)
 	buf := new(bytes.Buffer)
 	clusterAddr, err := c.clusterAddress()
-	clusterIpFamily, err := c.clusterIpFamily()
 	if err != nil {
 		return nil, fmt.Errorf("error getting cluster address: %v", err)
+	}
+	clusterIpFamily, err := c.clusterIpFamily()
+	if err != nil {
+		return nil, fmt.Errorf("error getting cluster ip family: %v", err)
 	}
 	sst, err := galera.SST.MariaDBFormat()
 	if err != nil {
@@ -119,8 +122,11 @@ func (c *ConfigFile) clusterAddress() (string, error) {
 }
 
 func (c *ConfigFile) clusterIpFamily() (string, error) {
-	clusterIP := os.Getenv("MARIADB_GALERA_SERVICE_HOST")
-	parsedIP := net.ParseIP(clusterIP)
+	galeraServiceHost := os.Getenv("MARIADB_GALERA_SERVICE_HOST")
+	if galeraServiceHost == "" {
+		return "", errors.New("error fetching envvar MARIADB_GALERA_SERVICE_HOST")
+	}
+	parsedIP := net.ParseIP(galeraServiceHost)
 	if parsedIP.To4() != nil {
 		return fmt.Sprintf("4"), nil
 	} else {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -92,7 +92,7 @@ func TestConfigMarshal(t *testing.T) {
 			mariadbRootPassword: "mariadb",
 			//nolint:lll
 			wantConfig: `[mariadb]
-bind-address=0.0.0.0
+bind-address=*
 default_storage_engine=InnoDB
 binlog_format=row
 innodb_autoinc_lock_mode=2
@@ -139,7 +139,7 @@ wsrep_sst_method="rsync"
 			mariadbRootPassword: "mariadb",
 			//nolint:lll
 			wantConfig: `[mariadb]
-bind-address=0.0.0.0
+bind-address=*
 default_storage_engine=InnoDB
 binlog_format=row
 innodb_autoinc_lock_mode=2

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -103,6 +103,7 @@ wsrep_provider=/usr/lib/galera/libgalera_smm.so
 wsrep_cluster_address="gcomm://mariadb-galera-0.mariadb-galera-internal.default.svc.cluster.local,mariadb-galera-1.mariadb-galera-internal.default.svc.cluster.local,mariadb-galera-2.mariadb-galera-internal.default.svc.cluster.local"
 wsrep_cluster_name=mariadb-operator
 wsrep_slave_threads=1
+wsrep_provider_options="gmcast.listen_addr=tcp://[::]:4567; ist.recv_addr=mariadb-galera-0.mariadb-galera-internal.default.svc.cluster.local:4568"
 
 # Node configuration
 wsrep_node_address="mariadb-galera-0.mariadb-galera-internal.default.svc.cluster.local"
@@ -150,6 +151,7 @@ wsrep_provider=/usr/lib/galera/libgalera_smm.so
 wsrep_cluster_address="gcomm://mariadb-galera-0.mariadb-galera-internal.default.svc.cluster.local,mariadb-galera-1.mariadb-galera-internal.default.svc.cluster.local,mariadb-galera-2.mariadb-galera-internal.default.svc.cluster.local"
 wsrep_cluster_name=mariadb-operator
 wsrep_slave_threads=2
+wsrep_provider_options="gmcast.listen_addr=tcp://[::]:4567; ist.recv_addr=mariadb-galera-1.mariadb-galera-internal.default.svc.cluster.local:4568"
 
 # Node configuration
 wsrep_node_address="mariadb-galera-1.mariadb-galera-internal.default.svc.cluster.local"


### PR DESCRIPTION
Hello,

This PR allow Mariadb to bind on all interfaces IPv4 and IPv6 for the Galera side. 